### PR TITLE
Add Jest tests for salary calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Calculadora
+
+Este projeto inclui calculadoras em HTML para diversos propósitos. Os testes automatizados utilizam [Jest](https://jestjs.io/).
+
+## Executando os testes
+
+1. Instale as dependências (necessário acesso à internet):
+
+```bash
+npm install
+```
+
+2. Execute a suite de testes:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "calculadora",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/salario.test.js
+++ b/tests/salario.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const htmlPath = path.join(__dirname, '..', 'calculadoras-simples', 'scalc-salarioliquido.html');
+const html = fs.readFileSync(htmlPath, 'utf-8');
+const dom = new JSDOM(html, { runScripts: 'dangerously' });
+const { calcularINSS } = dom.window;
+
+describe('calcularINSS', () => {
+  test('salário até 2571.29', () => {
+    expect(calcularINSS(2000)).toBeCloseTo(160.2, 2);
+  });
+
+  test('salário até 3856.94', () => {
+    expect(calcularINSS(3000)).toBeCloseTo(263.0613, 2);
+  });
+
+  test('salário até 7507.49', () => {
+    expect(calcularINSS(5000)).toBeCloseTo(525.9225, 2);
+  });
+
+  test('salário acima do teto', () => {
+    expect(calcularINSS(8000)).toBeCloseTo(876.9711, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with jsdom
- add README instructions on how to run tests
- create tests/salario.test.js covering INSS ranges

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa1c1e818832d8c63e0ec4eee623d